### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/testbysunil/3409db6a-40d7-4309-bf81-e1debd5ec482/1f0b334c-8b97-4907-b7d4-4b736275bbe5/_apis/work/boardbadge/0ada9a48-6126-4b0f-bd4d-63fac7dd3fd8)](https://dev.azure.com/testbysunil/3409db6a-40d7-4309-bf81-e1debd5ec482/_boards/board/t/1f0b334c-8b97-4907-b7d4-4b736275bbe5/Microsoft.RequirementCategory)
 # test1


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/testbysunil/3409db6a-40d7-4309-bf81-e1debd5ec482/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.